### PR TITLE
Improve environment name constraints, remove unused icon, and downgrade node version for web build

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -170,7 +170,7 @@ module containerApps 'core/host/container-apps.bicep' = {
     name: 'app'
     location: location
     tags: tags
-    containerAppsEnvironmentName: '${take(replace(prefix, '--', '-'), 64-7)}-ca-env'
+    containerAppsEnvironmentName: '${take(replace(prefix, '--', '-'), 60-7)}-ca-env'
     containerRegistryName: ai.outputs.containerRegistryName
     logAnalyticsWorkspaceName: ai.outputs.logAnalyticsWorkspaceName
   }

--- a/src/web/Dockerfile
+++ b/src/web/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:20-alpine AS ui
+FROM node:20.11.1-alpine3.19 AS ui
 WORKDIR /app
 
 # Copy package files and install dependencies

--- a/src/web/src/components/toolbar.tsx
+++ b/src/web/src/components/toolbar.tsx
@@ -1,6 +1,5 @@
 import {
   BugAntIcon,
-  DocumentTextIcon,
   ArrowRightCircleIcon,
   ArrowLeftCircleIcon,
 } from "@heroicons/react/24/outline";


### PR DESCRIPTION
1. **Improve ACA environment name constraints** (`b4f39a7`)
   - Implement restrictions to ensure that the environment name in ACA (Application Configuration and Automation) does not exceed a specific length. This change prevents issues related to overly long environment names.

2. **Remove Unused DocumentTextIcon** (`a275bac`)
   - Clean up the codebase by removing the unused `DocumentTextIcon` component. This helps in keeping the repository neat and free of unnecessary components.

3. **Update Node Version for Web Build** (`d7a9481`)
   - Downgrade the required Node.js version for the web build process to `20.11`. This fixes some issues with the `remarkGemoji` plugin as well as some TS annotations