### PR TITLE
Downgrade Node.js version to 20.11 in devcontainer configuration to f…

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,9 @@
         "ghcr.io/devcontainers/features/git:1": {},
         "ghcr.io/azure/azure-dev/azd:latest": {},
         "ghcr.io/devcontainers/features/docker-in-docker:2": {},
-		"ghcr.io/devcontainers/features/node:1": {}
+		"ghcr.io/devcontainers/features/node:1": {
+            "version": "20.11"
+        }
     },
     "customizations": {
         "vscode": {


### PR DESCRIPTION
Downgrade the required Node.js version for the web build process to `20.11`. This fixes some issues with the `remarkGemoji` plugin as well as some TS annotations