### PR TITLE
Use PSRule for Security testing and re-enable manual testing

### DIFF
--- a/.github/workflows/azure-dev-validation.yaml
+++ b/.github/workflows/azure-dev-validation.yaml
@@ -8,6 +8,7 @@ on:
     branches: [ aca-openai-agent ]
     paths:
       - "infra/**"
+  workflow_dispatch:
 
 jobs:
   build:
@@ -22,15 +23,23 @@ jobs:
         with:
           inlineScript: az config set bicep.use_binary_from_path=false && az bicep build -f infra/main.bicep --stdout
 
-      - name: Run Microsoft Security DevOps Analysis
-        uses: microsoft/security-devops-action@preview
-        id: msdo
-        continue-on-error: true
+      - name: Run PSRule analysis
+        uses: microsoft/ps-rule@v2.9.0
         with:
-          tools: templateanalyzer
+          modules: PSRule.Rules.Azure
+          baseline: Azure.Pillar.Security
+          inputPath: infra/*.test.bicep
+          outputFormat: Sarif
+          outputPath: reports/ps-rule-results.sarif
+          summary: true
+        continue-on-error: true
+          
+        env:
+          PSRULE_CONFIGURATION_AZURE_BICEP_FILE_EXPANSION: 'true'
+          PSRULE_CONFIGURATION_AZURE_BICEP_FILE_EXPANSION_TIMEOUT: '30'
 
       - name: Upload alerts to Security tab
         uses: github/codeql-action/upload-sarif@v2
         if: github.repository == 'Azure-Samples/contoso-creative-writer'
         with:
-          sarif_file: ${{ steps.msdo.outputs.sarifFile }}
+          sarif_file: reports/ps-rule-results.sarif

--- a/.github/workflows/azure-dev-validation.yaml
+++ b/.github/workflows/azure-dev-validation.yaml
@@ -5,7 +5,7 @@ on:
     paths:
       - "infra/**"
   pull_request:
-    branches: [ aca-openai-agent ]
+    branches: [ main ]
     paths:
       - "infra/**"
   workflow_dispatch:

--- a/infra/main.test.bicep
+++ b/infra/main.test.bicep
@@ -1,0 +1,17 @@
+// This file is for doing static analysis and contains sensible defaults
+// for PSRule to minimise false-positives and provide the best results.
+
+// This file is not intended to be used as a runtime configuration file.
+
+targetScope = 'subscription'
+
+param environmentName string = 'testing'
+param location string = 'swedencentral'
+
+module main 'main.bicep' = {
+  name: 'main'
+  params: {
+    environmentName: environmentName
+    location: location
+  }
+}


### PR DESCRIPTION
## Purpose

This uses a different rule for security testing that reduces false-positives and validates only what is deployed.