### PR TITLE
Activate local_tracing in main + Don't override max_tokens in writer.py

### DIFF
--- a/src/api/agents/writer/writer.py
+++ b/src/api/agents/writer/writer.py
@@ -11,7 +11,7 @@ def write(researchContext, research, productContext, products, assignment, feedb
 
     result = prompty.execute(
         "writer.prompty",
-        parameters={"stream": True, "max_tokens": 2000},
+        parameters={"stream": True},
         inputs={
             "researchContext": researchContext,
             "research": research,

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -15,7 +15,7 @@ base = Path(__file__).resolve().parent
 
 load_dotenv()
 LOCAL_TRACING = True if os.getenv("LOCAL_TRACING", "false").lower() == "true" else False
-tracer = init_tracing()
+tracer = init_tracing(local_tracing=LOCAL_TRACING)
 
 app = FastAPI()
 


### PR DESCRIPTION
- Activate local_tracing in main in order to demo the Prompty trace file VS Code extension
- Don't override max_tokens in writer.py in order to demo changing the max_tokens in the prompty file and demo the tracing