### PR TITLE
Add Local Prompty tracing support to 'evaluate.py` script

### DIFF
--- a/src/api/evaluate/evaluate.py
+++ b/src/api/evaluate/evaluate.py
@@ -153,7 +153,10 @@ if __name__ == "__main__":
     print(os.environ["BING_SEARCH_ENDPOINT"])
     print("value: ", os.environ["BING_SEARCH_KEY"], len(os.environ["BING_SEARCH_KEY"]))
 
-    tracer = init_tracing(local_tracing=True)
+    # Use LOCAL_TRACING to determine if we should use the PromptyTracer locally
+    # Never use remote_tracing for evaluation, it's not really relevant
+    LOCAL_TRACING = True if os.getenv("LOCAL_TRACING", "false").lower() == "true" else False
+    tracer = init_tracing(local_tracing=LOCAL_TRACING, remote_tracing=False)
 
     eval_result = evaluate_orchestrator(model_config, data_path=folder +"/eval_inputs.jsonl")
 

--- a/src/api/evaluate/evaluate.py
+++ b/src/api/evaluate/evaluate.py
@@ -9,6 +9,8 @@ from promptflow.core import AzureOpenAIModelConfiguration
 from promptflow.evals.evaluate import evaluate
 from evaluate.evaluators import ArticleEvaluator
 from orchestrator import create
+from prompty.tracer import trace
+from tracing import init_tracing
 
 from dotenv import load_dotenv
 
@@ -78,6 +80,7 @@ def run_orchestrator(research_context, product_context, assignment_context):
         "response": json.dumps(response),
     }
 
+@trace
 def evaluate_orchestrator(model_config, data_path):
     writer_evaluator = ArticleEvaluator(model_config)
 
@@ -149,6 +152,9 @@ if __name__ == "__main__":
     print(f"Starting evaluate...")
     print(os.environ["BING_SEARCH_ENDPOINT"])
     print("value: ", os.environ["BING_SEARCH_KEY"], len(os.environ["BING_SEARCH_KEY"]))
+
+    tracer = init_tracing(local_tracing=True)
+
     eval_result = evaluate_orchestrator(model_config, data_path=folder +"/eval_inputs.jsonl")
 
     end=time.time()

--- a/src/api/tracing.py
+++ b/src/api/tracing.py
@@ -27,13 +27,22 @@ def trace_span(name: str):
         yield verbose_trace
 
 
-def init_tracing(local_tracing: bool = False):
+def init_tracing(remote_tracing: bool, local_tracing: bool = False):
+    """
+    Initialize tracing for the application
+    If local_tracing is True, use the PromptyTracer
+    If remote_tracing is True, use the OpenTelemetry tracer
+    If remote_tracing is not specified, defaults to using the OpenTelemetry tracer only if local_tracing is False
+    """
+
+    if remote_tracing is None:
+        remote_tracing = not local_tracing
 
     if local_tracing:
         local_trace = PromptyTracer()
         Tracer.add("PromptyTracer", local_trace.tracer)
         # Tracer.add("ConsoleTracer", console_tracer)
-    else:
+    elif remote_tracing:
         Tracer.add("OpenTelemetry", trace_span)
 
     azmon_logger = logging.getLogger("azure")


### PR DESCRIPTION
This PR introduces changes to the `evaluate.py` and `tracing.py` files to enhance the tracing capabilities of the evaluation orchestration. The primary updates are as follows:

1. **Added Local Tracing Support in `evaluate.py` script**:
    - The `LOCAL_TRACING` env var is used to determine if local tracing (using `PromptyTracer`) should be enabled for evaluations
    - The `evaluate_orchestrator` function is now decorated with `@trace`

2. **Tracing Initialization**:
    - The `init_tracing` function in `tracing.py` is refactored to conditionally initialize local or remote tracing based on the parameters `local_tracing` and `remote_tracing`.
    - If `local_tracing` is enabled, it defaults to using the `PromptyTracer` and deactivating the `OpenTelemetry` tracer
    - If `remote_tracing` is explicitly specified, it will override the default behavior.

These changes preserve previous behavior while allowing to use local tracing in the `evaluate.py` script