### PR TITLE
Using gpt-4 for evals

### DIFF
--- a/infra/ai.yaml
+++ b/infra/ai.yaml
@@ -5,7 +5,7 @@ deployments:
     model:
       format: OpenAI
       name: gpt-35-turbo
-      version: "0613"
+      version: "1106"
     sku:
       name: Standard
       capacity: 20
@@ -23,7 +23,7 @@ deployments:
       name: gpt-4o
       version: "2024-05-13"
     sku:
-      name: "Standard"
+      name: "GlobalStandard"
       capacity: 20
   - name: gpt-4-evals
     model:

--- a/infra/ai.yaml
+++ b/infra/ai.yaml
@@ -28,8 +28,8 @@ deployments:
   - name: gpt-4-evals
     model:
       format: OpenAI
-      name: gpt-4o
-      version: "2024-05-13"
+      name: gpt-4
+      version: "0613"
     sku:
       name: "Standard"
-      capacity: 40
+      capacity: 10

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -6,6 +6,7 @@ targetScope = 'subscription'
 param environmentName string
 
 @allowed([
+  'canadaeast'
   'eastus'
   'eastus2'
   'northcentralus'


### PR DESCRIPTION
- Using `gpt-4` for evals
- Adding `canadaeast` to allowed regions
- `canadaeast` only has `gpt-4o` in sku `GlobalStandard` and `gpt-35-turbo` in version `1106`
