### PR TITLE
Upgrade to Prompty 0.1.19

### DIFF
--- a/src/api/requirements.txt
+++ b/src/api/requirements.txt
@@ -2,7 +2,7 @@ fastapi
 fastapi[standard]
 openai
 requests
-prompty
+prompty==0.1.19
 promptflow
 promptflow-evals
 pandas


### PR DESCRIPTION
In order to see the openai call params
![Screenshot 2024-09-03 at 2 39 08 PM](https://github.com/user-attachments/assets/e693e82b-2150-427d-b3d6-9c4a28422c12)
