### PR TITLE
Fix regex pattern in ghutils.ts

### DIFF
--- a/src/web/src/utils/ghutils.ts
+++ b/src/web/src/utils/ghutils.ts
@@ -1,6 +1,6 @@
 function githubDevSubsPort(hostname: string, port: number): string {
-    const regex = /-[0-9]{4,6}/gm;
-    const subst = `-${port}`;
+    const regex = /-[0-9]{4,6}\./gm;
+    const subst = `-${port}.`;
     let result = hostname.replace(regex, subst);
     if (!result.startsWith("https://")) {
         result = "https://"+ result;


### PR DESCRIPTION
## Purpose
If your Codespace has an identifier that starts with 4 to 6 digits, the regex in ghutils also replaces the identifier part of the hostname.
E.g. hostname of the web app is: https://ominous-space-broccoli-46556j4xjxpf4vg-5173.app.github.dev/ 
the regex changes the backend url to: https://ominous-space-broccoli-8000j4xjxpf4vg-8000.app.github.dev/
As a result the web app calls the wrong backend URL and lab 3 won't work.

An easy fix would be to include the "." in the regex and replace it with "-8000."

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
Start API and WebApp in Codespace
```

## What to Check
Verify that the following are valid
* Works with an identifier of a Codespace that doesn't start with a 4 to 6 digit number
* Works with an identifier of a Codespace that starts with a 4 to 6 digit number

## Other Information
I don't know how high the probability for such a scenario is, but if you get an identifier starting with 4 to 6 digits, the local test of the applications won't work in the Codespace