### PR TITLE
Lab script fetch track fork

### DIFF
--- a/docs/workshop/lab_setup.py
+++ b/docs/workshop/lab_setup.py
@@ -74,6 +74,15 @@ def fork_repository():
     out, err = process.communicate()
     print(out)
 
+@step("Fetch Origin")
+def fetch_origin():
+    """
+    Fetch the latest changes from origin.
+
+    Necessary because after forking repository, main is still tracking upstream and origin has not been fetched.
+    """
+    subprocess.run(['git', 'fetch', 'origin'], check=True)
+
 @step("Azure CLI Authentication")
 def azure_login(*, username: str = None, password: str = None, tenant: str = None, force: bool = False):
     # Only check authentication status if not forcing re-auth

--- a/docs/workshop/lab_setup.py
+++ b/docs/workshop/lab_setup.py
@@ -79,9 +79,18 @@ def fetch_origin():
     """
     Fetch the latest changes from origin.
 
-    Necessary because after forking repository, main is still tracking upstream and origin has not been fetched.
+    Necessary because after forking repository, origin has not been fetched.
     """
     subprocess.run(['git', 'fetch', 'origin'], check=True)
+
+@step("Track origin/main")
+def track_origin_main():
+    """
+    Set the main branch to track origin/main instead of upstream/main
+
+    Necessary because after forking repository, main is still tracking upstream.
+    """
+    subprocess.run(['git', 'branch', 'main', '--set-upstream-to', 'origin/main'], check=True)
 
 @step("Azure CLI Authentication")
 def azure_login(*, username: str = None, password: str = None, tenant: str = None, force: bool = False):


### PR DESCRIPTION
Added two steps after repo fork `fetch_origin` and `track_origin_main` because after forking the repository, `main` is still tracking `upstream` instead of `origin` and `origin` has not been fetched.